### PR TITLE
Handle when --team is not set

### DIFF
--- a/merge2csv.py
+++ b/merge2csv.py
@@ -144,7 +144,10 @@ else:
 if args.outfilename is not None:
     outfilename = args.outfilename
 else:
-    outfilename = 'merges-%s.csv' % args.COMPONENT
+    outfilename = 'merges-%s' % args.COMPONENT
+    if args.team:
+        outfilename += '-%s' % args.team
+    outfilename += ".csv"
 
 with open(outfilename, 'w') as f:
     writer = csv.writer(f, lineterminator="\n")
@@ -212,6 +215,8 @@ with open(outfilename, 'w') as f:
                         else:
                             package['responsibility'] = teamname
                         value = package.get(key, '')
+                        skip = False
+                        break
                     else:
                         skip = True
             else:


### PR DESCRIPTION
Without a team name, no packages are written to the outputfile due to skip flag
being set to True;  In the inner loop, reset skip to False and break out if we
found a match.

Second, if a team is specified, automatically append it to the output filename.

Signed-off-by: Ryan Harper <ryan.harper@canonical.com>